### PR TITLE
Implement a couple of tools: `build`, `tool`, `sources`, and `deps`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-bazel-mcp
+mcp-bazel

--- a/bazel/execute.go
+++ b/bazel/execute.go
@@ -1,0 +1,24 @@
+package bazel
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+// ExecuteCommand runs a bazel command in the given directory and returns its combined stdout/stderr.
+// The first argument in 'args' should be the bazel command (e.g., "query", "build", "test").
+// If the command fails, it returns an error including the combined output.
+func ExecuteCommand(ctx context.Context, workingDir string, args ...string) (string, error) {
+	// Command is assumed to be "bazel"
+	cmd := exec.CommandContext(ctx, "bazel", args...)
+	cmd.Dir = workingDir
+
+	output, err := cmd.CombinedOutput() // Use CombinedOutput to get stdout and stderr
+	if err != nil {
+		// The error already includes command details and potentially exit code.
+		// CombinedOutput includes stderr in the output on error.
+		return string(output), fmt.Errorf("bazel command failed: %w\nArgs: %v\nOutput:\n%s", err, args, string(output))
+	}
+	return string(output), nil
+}

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 
 	"github.com/aaomidi/mcp-bazel/tools/build"
+	"github.com/aaomidi/mcp-bazel/tools/deps"
 	"github.com/aaomidi/mcp-bazel/tools/rdeps"
 	"github.com/aaomidi/mcp-bazel/tools/sources"
 	"github.com/aaomidi/mcp-bazel/tools/test"
@@ -22,6 +23,7 @@ func _main() error {
 	s.AddTool(build.Tool, build.Handler)
 	s.AddTool(test.Tool, test.Handler)
 	s.AddTool(sources.Tool, sources.Handler)
+	s.AddTool(deps.Tool, deps.Handler)
 
 	return server.ServeStdio(s)
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 
+	"github.com/aaomidi/mcp-bazel/tools/build"
 	"github.com/aaomidi/mcp-bazel/tools/rdeps"
 
 	"github.com/mark3labs/mcp-go/server"
@@ -16,6 +17,7 @@ func _main() error {
 
 	// Register tools
 	s.AddTool(rdeps.Tool, rdeps.Handler)
+	s.AddTool(build.Tool, build.Handler)
 
 	return server.ServeStdio(s)
 }

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aaomidi/mcp-bazel/tools/build"
 	"github.com/aaomidi/mcp-bazel/tools/rdeps"
+	"github.com/aaomidi/mcp-bazel/tools/test"
 
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -18,6 +19,7 @@ func _main() error {
 	// Register tools
 	s.AddTool(rdeps.Tool, rdeps.Handler)
 	s.AddTool(build.Tool, build.Handler)
+	s.AddTool(test.Tool, test.Handler)
 
 	return server.ServeStdio(s)
 }

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aaomidi/mcp-bazel/tools/build"
 	"github.com/aaomidi/mcp-bazel/tools/rdeps"
+	"github.com/aaomidi/mcp-bazel/tools/sources"
 	"github.com/aaomidi/mcp-bazel/tools/test"
 
 	"github.com/mark3labs/mcp-go/server"
@@ -20,6 +21,7 @@ func _main() error {
 	s.AddTool(rdeps.Tool, rdeps.Handler)
 	s.AddTool(build.Tool, build.Handler)
 	s.AddTool(test.Tool, test.Handler)
+	s.AddTool(sources.Tool, sources.Handler)
 
 	return server.ServeStdio(s)
 }

--- a/main.go
+++ b/main.go
@@ -1,15 +1,10 @@
 package main
 
 import (
-	"context"
-	"errors"
-	"fmt"
 	"log"
-	"os/exec"
 
-	"github.com/aaomidi/mcp-bazel/bazel"
+	"github.com/aaomidi/mcp-bazel/tools/rdeps"
 
-	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
 
@@ -19,87 +14,10 @@ func _main() error {
 		"0.0.1",
 	)
 
-	rdepsTarget := mcp.NewTool("reverse-dependencies",
-		mcp.WithDescription("Given a bazel target, or file path, find all other bazel targets that depend on it."),
-		mcp.WithString("target",
-			mcp.Required(),
-			mcp.Description("The target to find reverse dependencies for."),
-		),
-		mcp.WithString("project_path",
-			mcp.Required(),
-			mcp.Description("Where MODULE.bazel or WORKSPACE is located."),
-		),
-		mcp.WithNumber("max_depth",
-			mcp.Description("The maximum depth to search for reverse dependencies. Set to -1 to search indefinitely. 1 finds the immediate targets."),
-			mcp.DefaultNumber(-1),
-		),
-	)
-
-	s.AddTool(rdepsTarget, reverseDependenciesToolHandler)
+	// Register tools
+	s.AddTool(rdeps.Tool, rdeps.Handler)
 
 	return server.ServeStdio(s)
-}
-
-// executeCommand runs a shell command in the given directory and returns its stdout.
-// If the command fails, it returns an error including stderr.
-func executeCommand(ctx context.Context, workingDir string, command string) (string, error) {
-	cmd := exec.CommandContext(ctx, "bash", "-c", command)
-	cmd.Dir = workingDir
-
-	output, err := cmd.Output()
-	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok {
-			return "", fmt.Errorf("command failed: %v\nstderr: %s", err, string(exitErr.Stderr))
-		}
-		return "", fmt.Errorf("failed to run command: %w", err)
-	}
-	return string(output), nil
-}
-
-func reverseDependenciesToolHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	targetInput, ok := request.Params.Arguments["target"].(string)
-	if !ok {
-		return nil, errors.New("target must be a string")
-	}
-
-	projectPath, ok := request.Params.Arguments["project_path"].(string)
-	if !ok {
-		return nil, errors.New("project_path must be a string")
-	}
-
-	// MCP sends numbers as float64, so we need to retrieve and convert
-	maxDepthFloat, ok := request.Params.Arguments["max_depth"].(float64)
-	if !ok {
-		log.Printf("Warning: max_depth argument was not a float64, using default -1. Value received: %v", request.Params.Arguments["max_depth"])
-		maxDepthFloat = -1 // Default manually if type assertion fails
-	}
-	maxDepth := int(maxDepthFloat)
-
-	bazelTarget, err := bazel.ResolveInputToBazelTarget(targetInput, projectPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve input %q to bazel target: %w", targetInput, err)
-	}
-
-	var cmdStr string
-	queryScope := "//..." // Default scope for rdeps
-
-	if maxDepth > 0 {
-		// Use depth-limited rdeps query: rdeps(universe, target, depth)
-		cmdStr = fmt.Sprintf("bazel query 'rdeps(%s, %s, %d)' --output graph", queryScope, bazelTarget, maxDepth)
-	} else {
-		// Use standard rdeps query (depth <= 0 means unlimited): rdeps(universe, target)
-		cmdStr = fmt.Sprintf("bazel query 'rdeps(%s, %s)' --output graph", queryScope, bazelTarget)
-	}
-
-	log.Printf("Executing command: [%s] in directory: [%s]", cmdStr, projectPath)
-
-	output, err := executeCommand(ctx, projectPath, cmdStr)
-	if err != nil {
-		// Provide more context in the error message
-		return nil, fmt.Errorf("failed to execute bazel query for target %q (derived from input %q) with depth %d: %w", bazelTarget, targetInput, maxDepth, err)
-	}
-
-	return mcp.NewToolResultText(output), nil
 }
 
 func main() {

--- a/tools/build/build.go
+++ b/tools/build/build.go
@@ -1,0 +1,55 @@
+package build
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/aaomidi/mcp-bazel/bazel"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// Tool defines the MCP tool for building Bazel targets.
+var Tool = mcp.NewTool("build",
+	mcp.WithDescription("Builds a given Bazel target."),
+	mcp.WithString("target",
+		mcp.Required(),
+		mcp.Description("The Bazel target to build (e.g., //foo:bar)."),
+	),
+	mcp.WithString("project_path",
+		mcp.Required(),
+		mcp.Description("Where MODULE.bazel or WORKSPACE is located."),
+	),
+)
+
+// Handler implements the logic for the build tool.
+func Handler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	target, ok := request.Params.Arguments["target"].(string)
+	if !ok {
+		return nil, errors.New("target must be a string")
+	}
+	// Basic validation: Ensure target isn't empty (more robust validation could be added)
+	if target == "" {
+		return nil, errors.New("target cannot be empty")
+	}
+
+	projectPath, ok := request.Params.Arguments["project_path"].(string)
+	if !ok {
+		return nil, errors.New("project_path must be a string")
+	}
+
+	// Build the bazel build arguments
+	buildArgs := []string{"build", target}
+
+	log.Printf("Executing bazel command with args: %v in directory: [%s]", buildArgs, projectPath)
+
+	output, err := bazel.ExecuteCommand(ctx, projectPath, buildArgs...)
+	if err != nil {
+		// Error from ExecuteCommand includes command output which is useful for build failures
+		return nil, fmt.Errorf("failed to execute bazel build for target %q: %w", target, err)
+	}
+
+	// On success, the output might contain build information or be empty.
+	return mcp.NewToolResultText(output), nil
+}

--- a/tools/deps/deps.go
+++ b/tools/deps/deps.go
@@ -1,0 +1,79 @@
+package deps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/aaomidi/mcp-bazel/bazel"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// Tool defines the MCP tool for finding dependencies of a Bazel target.
+var Tool = mcp.NewTool("deps",
+	mcp.WithDescription("Finds the dependencies of a given Bazel target."),
+	mcp.WithString("target",
+		mcp.Required(),
+		mcp.Description("The Bazel target to find dependencies for (e.g., //foo:bar)."),
+	),
+	mcp.WithString("project_path",
+		mcp.Required(),
+		mcp.Description("Where MODULE.bazel or WORKSPACE is located."),
+	),
+	mcp.WithNumber("depth",
+		mcp.Description("The maximum depth for dependency search (default: 1 for direct deps). Must be non-negative."),
+		mcp.DefaultNumber(1),
+	),
+)
+
+// Handler implements the logic for the deps tool.
+func Handler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	// Extract Arguments
+	target, ok := request.Params.Arguments["target"].(string)
+	if !ok {
+		return nil, errors.New("target must be a string")
+	}
+	if target == "" {
+		return nil, errors.New("target cannot be empty")
+	}
+
+	projectPath, ok := request.Params.Arguments["project_path"].(string)
+	if !ok {
+		return nil, errors.New("project_path must be a string")
+	}
+	if projectPath == "" {
+		return nil, errors.New("project_path cannot be empty")
+	}
+
+	// Extract depth, defaulting to 1
+	depthFloat, ok := request.Params.Arguments["depth"].(float64)
+	if !ok {
+		log.Printf("Warning: depth argument was not a float64, using default 1. Value received: %v (%T)", request.Params.Arguments["depth"], request.Params.Arguments["depth"])
+		depthFloat = 1 // Default manually if type assertion fails or not present
+	}
+	depth := int(depthFloat)
+
+	// Validate depth
+	if depth < 0 {
+		return nil, fmt.Errorf("depth argument cannot be negative, got %d", depth)
+	}
+	if depthFloat != float64(depth) {
+		log.Printf("Warning: depth received non-integer number %f, using truncated value %d.", depthFloat, depth)
+		// Allow truncated non-negative values, consistent with bazel query behavior.
+	}
+
+	// Execute Logic
+	queryExpr := fmt.Sprintf("deps('%s', %d)", target, depth)
+	queryArgs := []string{"query", queryExpr, "--output", "label"}
+
+	log.Printf("Executing bazel command with args: %v in directory: [%s]", queryArgs, projectPath)
+
+	output, err := bazel.ExecuteCommand(ctx, projectPath, queryArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute bazel query for dependencies of target %q with depth %d: %w", target, depth, err)
+	}
+
+	// Return the list of dependency targets (one per line).
+	return mcp.NewToolResultText(output), nil
+}

--- a/tools/rdeps/rdeps.go
+++ b/tools/rdeps/rdeps.go
@@ -1,0 +1,78 @@
+package rdeps
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/aaomidi/mcp-bazel/bazel"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// Tool defines the MCP tool for finding reverse dependencies.
+var Tool = mcp.NewTool("reverse-dependencies",
+	mcp.WithDescription("Given a bazel target, or file path, find all other bazel targets that depend on it."),
+	mcp.WithString("target",
+		mcp.Required(),
+		mcp.Description("The target to find reverse dependencies for."),
+	),
+	mcp.WithString("project_path",
+		mcp.Required(),
+		mcp.Description("Where MODULE.bazel or WORKSPACE is located."),
+	),
+	mcp.WithNumber("max_depth",
+		mcp.Description("The maximum depth to search for reverse dependencies. Set to -1 to search indefinitely. 1 finds the immediate targets."),
+		mcp.DefaultNumber(-1),
+	),
+)
+
+// Handler implements the logic for the reverse dependencies tool.
+func Handler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	targetInput, ok := request.Params.Arguments["target"].(string)
+	if !ok {
+		return nil, errors.New("target must be a string")
+	}
+
+	projectPath, ok := request.Params.Arguments["project_path"].(string)
+	if !ok {
+		return nil, errors.New("project_path must be a string")
+	}
+
+	// MCP sends numbers as float64, so we need to retrieve and convert
+	maxDepthFloat, ok := request.Params.Arguments["max_depth"].(float64)
+	if !ok {
+		log.Printf("Warning: max_depth argument was not a float64, using default -1. Value received: %v", request.Params.Arguments["max_depth"])
+		maxDepthFloat = -1 // Default manually if type assertion fails
+	}
+	maxDepth := int(maxDepthFloat)
+
+	bazelTarget, err := bazel.ResolveInputToBazelTarget(targetInput, projectPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve input %q to bazel target: %w", targetInput, err)
+	}
+
+	// Build the bazel query arguments
+	queryArgs := []string{"query"}
+	queryScope := "//..." // Default scope for rdeps
+	queryExpr := ""
+
+	if maxDepth > 0 {
+		// Use depth-limited rdeps query: rdeps(universe, target, depth)
+		queryExpr = fmt.Sprintf("rdeps(%s, %s, %d)", queryScope, bazelTarget, maxDepth)
+	} else {
+		// Use standard rdeps query (depth <= 0 means unlimited): rdeps(universe, target)
+		queryExpr = fmt.Sprintf("rdeps(%s, %s)", queryScope, bazelTarget)
+	}
+	queryArgs = append(queryArgs, queryExpr, "--output", "graph")
+
+	log.Printf("Executing bazel command with args: %v in directory: [%s]", queryArgs, projectPath)
+
+	output, err := bazel.ExecuteCommand(ctx, projectPath, queryArgs...)
+	if err != nil {
+		// Error from ExecuteCommand already includes details and output
+		return nil, fmt.Errorf("failed to execute bazel query for target %q (derived from input %q) with depth %d: %w", bazelTarget, targetInput, maxDepth, err)
+	}
+
+	return mcp.NewToolResultText(output), nil
+}

--- a/tools/sources/sources.go
+++ b/tools/sources/sources.go
@@ -1,0 +1,58 @@
+package sources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/aaomidi/mcp-bazel/bazel"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// Tool defines the MCP tool for finding source files of a Bazel target.
+var Tool = mcp.NewTool("sources",
+	mcp.WithDescription("Finds the direct source files associated with a given Bazel target."),
+	mcp.WithString("target",
+		mcp.Required(),
+		mcp.Description("The Bazel target to find sources for (e.g., //foo:bar)."),
+	),
+	mcp.WithString("project_path",
+		mcp.Required(),
+		mcp.Description("Where MODULE.bazel or WORKSPACE is located."),
+	),
+)
+
+// Handler implements the logic for the sources tool.
+func Handler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	// --- Extract Arguments --- (Direct extraction, no common helpers)
+	target, ok := request.Params.Arguments["target"].(string)
+	if !ok {
+		return nil, errors.New("target must be a string")
+	}
+	if target == "" {
+		return nil, errors.New("target cannot be empty")
+	}
+
+	projectPath, ok := request.Params.Arguments["project_path"].(string)
+	if !ok {
+		return nil, errors.New("project_path must be a string")
+	}
+	if projectPath == "" {
+		return nil, errors.New("project_path cannot be empty")
+	}
+
+	// --- Execute Logic ---
+	queryExpr := fmt.Sprintf("kind('source file', deps('%s'))", target)
+	queryArgs := []string{"query", queryExpr, "--output", "label"}
+
+	log.Printf("Executing bazel command with args: %v in directory: [%s]", queryArgs, projectPath)
+
+	output, err := bazel.ExecuteCommand(ctx, projectPath, queryArgs...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute bazel query for sources of target %q: %w", target, err)
+	}
+
+	// Return the list of source files (one per line, as label output does).
+	return mcp.NewToolResultText(output), nil
+}

--- a/tools/test/test.go
+++ b/tools/test/test.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/aaomidi/mcp-bazel/bazel"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// Tool defines the MCP tool for testing Bazel targets.
+var Tool = mcp.NewTool("test",
+	mcp.WithDescription("Runs tests for a given Bazel target."),
+	mcp.WithString("target",
+		mcp.Required(),
+		mcp.Description("The Bazel target to test (e.g., //foo:test, //path/to/tests/...)."),
+	),
+	mcp.WithString("project_path",
+		mcp.Required(),
+		mcp.Description("Where MODULE.bazel or WORKSPACE is located."),
+	),
+)
+
+// Handler implements the logic for the test tool.
+func Handler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	target, ok := request.Params.Arguments["target"].(string)
+	if !ok {
+		return nil, errors.New("target must be a string")
+	}
+	if target == "" {
+		return nil, errors.New("target cannot be empty")
+	}
+
+	projectPath, ok := request.Params.Arguments["project_path"].(string)
+	if !ok {
+		return nil, errors.New("project_path must be a string")
+	}
+
+	// Build the bazel test arguments
+	testArgs := []string{"test", target}
+
+	log.Printf("Executing bazel command with args: %v in directory: [%s]", testArgs, projectPath)
+
+	output, err := bazel.ExecuteCommand(ctx, projectPath, testArgs...)
+	if err != nil {
+		// Error from ExecuteCommand includes command output which is useful for test failures
+		return nil, fmt.Errorf("failed to execute bazel test for target %q: %w", target, err)
+	}
+
+	// On success, the output contains the test summary.
+	return mcp.NewToolResultText(output), nil
+}


### PR DESCRIPTION
This pull request includes significant changes to the `mcp-bazel` project, focusing on refactoring the codebase to modularize tool handlers and improve the execution of Bazel commands. The most important changes include adding new tool handlers for various Bazel operations, moving existing logic to separate files, and refactoring the main file to register these tools.

### Refactoring and Modularization:

* **New Tool Handlers:**
  * [`tools/build/build.go`](diffhunk://#diff-1465b547457e2696438a2ca00d69527f27bfaec6f826795a4da1a2812f46437cR1-R55): Added a new tool handler for building Bazel targets, including argument validation and command execution logic.
  * [`tools/deps/deps.go`](diffhunk://#diff-13b74eae1f9cd657c1d5d828d8d9c477e8d668158835fe19cb34dfccb930c6bfR1-R79): Added a new tool handler for finding dependencies of a Bazel target, with depth validation and command execution.
  * [`tools/rdeps/rdeps.go`](diffhunk://#diff-3b9d231f19d7f247a48725c46a6cc2d727c4fbe9acbfb1159a0de6901afb1890R1-R78): Added a new tool handler for finding reverse dependencies of a Bazel target, replacing the previous inline logic.
  * [`tools/sources/sources.go`](diffhunk://#diff-ec8726174275e413834c1ae99456842490f098a10e116a5743cdcb8549aad5bdR1-R58): Added a new tool handler for finding source files of a Bazel target.
  * [`tools/test/test.go`](diffhunk://#diff-ab2538976b1c47f6b3b6903a85ecb55f17b8905ae7c25a9d25210495c90d1168R1-R54): Added a new tool handler for running tests on Bazel targets.

* **Main File Refactoring:**
  * [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L4-L12): Refactored the main file to remove inline tool handler logic and instead register the new modularized tool handlers. This improves code readability and maintainability. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L4-L12) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L22-L104)

### Command Execution:

* **Bazel Command Execution:**
  * [`bazel/execute.go`](diffhunk://#diff-44be6d6e99a9b23b384e64b7b14a341c9b9243a1c85b141f428470d43099c391R1-R24): Added a new function `ExecuteCommand` to handle the execution of Bazel commands, capturing both stdout and stderr, and returning detailed error messages if the command fails.