### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aaomidi/mcp-bazel
 
-go 1.24.2
+go 1.24
 
 require github.com/mark3labs/mcp-go v0.18.0
 


### PR DESCRIPTION
Installation doesn't work 
```
❯ go install github.com/aaomidi/mcp-bazel@latest

go: github.com/aaomidi/mcp-bazel@latest (in github.com/aaomidi/mcp-bazel@v0.0.0-20250407033914-71827c505ad9): go.mod:3: invalid go version '1.24.2': must match format 1.23
❯ go version
go version go1.20.2 linux/amd64
```